### PR TITLE
Plugin updates for Zeek v4.1.x compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,15 +15,15 @@ By default it will not log passwords, but only log the username in a `post_usern
 
    # or for legacy installs
 
-   $ bro-pkg install zeek-sniffpass
+   $ zkg install zeek-sniffpass
    ```
-- Download the files to `$PREFIX/bro/share/bro/site/sniffpass` and add the following to your `local.bro`:
+- Download the files to `$PREFIX/zeek/share/zeek/site/sniffpass` and add the following to your `local.zeek`:
     ```bash
     @load ./sniffpass
     ```
 
 # Configuring
-- You can enable different types of password logging. Add one (or more) of the following options to your `local.bro` file:
+- You can enable different types of password logging. Add one (or more) of the following options to your `local.zeek` file:
     ```
     redef SNIFFPASS::log_password_plaintext = T;
     redef SNIFFPASS::log_password_md5 = T;
@@ -35,7 +35,7 @@ By default it will not log passwords, but only log the username in a `post_usern
     redef SNIFFPASS::notice_log_enable = F;
     ```
 
-- By default, only the first 300 bytes of an HTTP POST request are parsed. This can be changed by adding the following to your `local.bro` file and setting your own value:
+- By default, only the first 300 bytes of an HTTP POST request are parsed. This can be changed by adding the following to your `local.zeek` file and setting your own value:
     ```
     redef SNIFFPASS::post_body_limit = 300
     ```
@@ -103,7 +103,7 @@ The output from the Example Python Script:
 Automated tests are done against the `http_post.trace` file with Travis CI.
 
 # Troubleshooting
-- If you are having any issues, ensure that you have TCP Checksumming disabled in your `local.bro` file, as per [Zeek Documentation](https://www.zeek.org/documentation/faq.html#why-isn-t-zeek-producing-the-logs-i-expect-a-note-about-checksums)
+- If you are having any issues, ensure that you have TCP Checksumming disabled in your `local.zeek` file, as per [Zeek Documentation](https://www.zeek.org/documentation/faq.html#why-isn-t-zeek-producing-the-logs-i-expect-a-note-about-checksums)
 
     ```
     redef ignore_checksums = T;

--- a/scripts/__load__.bro
+++ b/scripts/__load__.bro
@@ -1,1 +1,0 @@
-@load ./main.bro

--- a/scripts/__load__.zeek
+++ b/scripts/__load__.zeek
@@ -1,0 +1,1 @@
+@load ./main.zeek

--- a/scripts/main.zeek
+++ b/scripts/main.zeek
@@ -100,15 +100,17 @@ event http_message_done(c: connection, is_orig: bool, stat: http_message_stat)
     {
         local post_parsed = split_string(c$sp$post_data, /&/);
         local password_seen = F;
+        local username_value = "";
+        local password_value = "";
 
         for (p in post_parsed) {
             local kv = split_string1(post_parsed[p], /=/);
             if (to_upper(kv[0]) in username_fields) {
-                local username_value = kv[1];
+                username_value = kv[1];
                 c$http$post_username = username_value;
             }
             if (to_upper(kv[0]) in password_fields) {
-                local password_value = kv[1];
+                password_value = kv[1];
                 password_seen = T;
 
                 if ( log_password_plaintext )

--- a/scripts/main.zeek
+++ b/scripts/main.zeek
@@ -146,12 +146,7 @@ event http_message_done(c: connection, is_orig: bool, stat: http_message_stat)
     }
 }
 
-# Use zeek_init for version 3+
-@ifdef ( zeek_init )
 event zeek_init()
-@else
-event bro_init()
-@endif
 {
     # Only use Broker if it's available
     @ifdef (Broker::auto_publish)


### PR DESCRIPTION
- Rename deprecated (now removed) "bro" references to "zeek"
- Changes in this branch now work in Zeek v4.0.x (LTS) and Zeek v4.1.x+ (feature).